### PR TITLE
Fix uninstall using default uninstall script

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -6,10 +6,10 @@ case "$1" in
 
   configure)
 
-    if lsmod | grep v4l2loopback_dc >/dev/null; then
-      rmmod v4l2loopback-dc
-      rm -f /lib/modules/`uname -r`/kernel/drivers/media/video/v4l2loopback-dc.ko
-    fi
+    # if lsmod | grep v4l2loopback_dc >/dev/null; then
+    #   rmmod v4l2loopback-dc
+    #   rm -f /lib/modules/`uname -r`/kernel/drivers/media/video/v4l2loopback-dc.ko
+    # fi
     cd /opt/droidcam/
     unzip -uo droidcam_1593923604.zip
     ./install

--- a/debian/postrm
+++ b/debian/postrm
@@ -5,16 +5,19 @@ set -e
 case "$1" in
   purge|remove)
     if [ -e /opt/droidcam ]; then
+      cd /opt/droidcam
+      ./uninstall
       rm -rf /opt/droidcam
-      rmmod v4l2loopback-dc
-      rm -f /lib/modules/`uname -r`/kernel/drivers/media/video/v4l2loopback-dc.ko
-      rm -f /usr/bin/droidcam
-      rm -f /usr/bin/droidcam-cli
-      cat /etc/modules | egrep -v "^(videodev|v4l2loopback-dc)" > /tmp/.etc.modules
-      prevperm=`stat -c %a /etc/modules`
-      mv /tmp/.etc.modules /etc/modules
-      chmod $prevperm /etc/modules
       rm /opt/droidcam-uninstall
+      ##All the following are automatically managed by uninstall script
+      # rmmod v4l2loopback-dc
+      # # rm -f /usr/bin/droidcam
+      # # rm -f /usr/bin/droidcam-cli
+      # rm -f /lib/modules/`uname -r`/kernel/drivers/media/video/v4l2loopback-dc.ko
+      # cat /etc/modules | egrep -v "^(videodev|v4l2loopback-dc)" > /tmp/.etc.modules
+      # prevperm=`stat -c %a /etc/modules`
+      # mv /tmp/.etc.modules /etc/modules
+      # chmod $prevperm /etc/modules
     fi
   ;;
 


### PR DESCRIPTION
Previously, if Droidcam was opened, it could not be uninstalled unless the computer was restarted.

I have not pushed this to Launchpad, I will not do that until everything is tested to be perfect.